### PR TITLE
MySQL support; Making REM work

### DIFF
--- a/src/main/java/net/simplyvanilla/simplyrank/SimplyRankPlugin.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/SimplyRankPlugin.java
@@ -7,6 +7,7 @@ import net.simplyvanilla.simplyrank.command.SimplyRankCommandExecutor;
 import net.simplyvanilla.simplyrank.data.DataManager;
 import net.simplyvanilla.simplyrank.data.GroupData;
 import net.simplyvanilla.simplyrank.data.IOCallback;
+import net.simplyvanilla.simplyrank.data.SQLHandler;
 import net.simplyvanilla.simplyrank.gson.ChatColorGsonDeserializer;
 import net.simplyvanilla.simplyrank.placeholder.SimplyRankPlaceholderExpansion;
 import org.bukkit.ChatColor;
@@ -21,6 +22,7 @@ public class SimplyRankPlugin extends JavaPlugin {
 
     private static SimplyRankPlugin instance;
     private DataManager dataManager;
+    private SQLHandler sqlHandler;
 
     @Override
     public void onEnable() {
@@ -58,7 +60,9 @@ public class SimplyRankPlugin extends JavaPlugin {
             }
         }
 
-        dataManager = new DataManager(gson, groupFolder, playerFolder);
+        //dataManager = new DataManager(gson, groupFolder, playerFolder);
+        sqlHandler = new SQLHandler("localhost", "minecraft-simplyrank", "root", "1234", "3366");
+        dataManager = new DataManager(gson, sqlHandler);
 
         if (!dataManager.groupExists("default")) {
             GroupData defaultData = new GroupData(ChatColor.GRAY, "Member ");
@@ -69,7 +73,7 @@ public class SimplyRankPlugin extends JavaPlugin {
                 }
 
                 @Override
-                public void error(IOException error) {
+                public void error(Exception error) {
                     getLogger().info("There was an error creating the default group");
                 }
             });
@@ -83,6 +87,7 @@ public class SimplyRankPlugin extends JavaPlugin {
     @Override
     public void onDisable() {
         instance = null;
+        sqlHandler.close();
     }
 
     public DataManager getDataManager() {

--- a/src/main/java/net/simplyvanilla/simplyrank/SimplyRankPlugin.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/SimplyRankPlugin.java
@@ -62,7 +62,7 @@ public class SimplyRankPlugin extends JavaPlugin {
 
         if (!dataManager.groupExists("default")) {
             GroupData defaultData = new GroupData(ChatColor.GRAY, "Member ");
-            dataManager.saveGroupData("default", defaultData, new IOCallback<>() {
+            dataManager.saveGroupDataAsync("default", defaultData, new IOCallback<>() {
                 @Override
                 public void success(Void data) {
                     getLogger().info("Successfully created default group!");

--- a/src/main/java/net/simplyvanilla/simplyrank/command/SimplyRankCommandExecutor.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/command/SimplyRankCommandExecutor.java
@@ -237,7 +237,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
                     return true;
                 }
 
-                UUID uuidLookup = null; //Has to be final to be accessable in callback
+                UUID uuidLookup = null;
                 Player target = Bukkit.getPlayer(name);
                 if (target != null) {
                     uuidLookup = target.getUniqueId();
@@ -248,7 +248,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
                     }
                 }
 
-                final String group = args[2];
+                final String group = args[2]; //Has to be final to be accessible in callback
                 final UUID uuid = uuidLookup != null ? uuidLookup : UUID.fromString(name);  //Working both by using uuid and name
                 //First, fetch the current data
                 dataManager.loadPlayerDataAsync(uuid, new IOCallback<>() {

--- a/src/main/java/net/simplyvanilla/simplyrank/command/SimplyRankCommandExecutor.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/command/SimplyRankCommandExecutor.java
@@ -64,7 +64,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
                     }
 
                     GroupData groupData = new GroupData(color, prefix);
-                    dataManager.saveGroupData(name, groupData, new IOCallback<>() {
+                    dataManager.saveGroupDataAsync(name, groupData, new IOCallback<>() {
                         @Override
                         public void success(Void data) {
                             sender.sendMessage("Successfully created the group!");
@@ -113,7 +113,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
                 }
 
                 String uuidString = uuid.toString();
-                dataManager.loadPlayerData(uuid, new IOCallback<>() {
+                dataManager.loadPlayerDataAsync(uuid, new IOCallback<>() {
                     @Override
                     public void success(PlayerData data) {
                         coreSetCommandHandler(sender, group, uuidString, data);
@@ -165,7 +165,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
                 }
 
                 String uuidString = uuid.toString();
-                dataManager.loadPlayerData(uuid, new IOCallback<>() {
+                dataManager.loadPlayerDataAsync(uuid, new IOCallback<>() {
                     @Override
                     public void success(PlayerData data) {
                         coreAddCommandHandler(sender, group, uuidString, data);
@@ -209,7 +209,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
                     return true;
                 }
 
-                dataManager.loadPlayerData(uuid, new IOCallback<>() {
+                dataManager.loadPlayerDataAsync(uuid, new IOCallback<>() {
                     @Override
                     public void success(PlayerData data) {
                         sender.sendMessage("Groups from " + name + ": [" + String.join(", ", data.getGroups()) + "]");
@@ -249,7 +249,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
 
                 String group = args[2];
 
-                dataManager.loadPlayerData(uuid, new IOCallback<>() {
+                dataManager.loadPlayerDataAsync(uuid, new IOCallback<>() {
                     @Override
                     public void success(PlayerData data) {
                         List<String> groups = data.getGroups();
@@ -297,7 +297,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
         newGroups.remove("default");
 
         data.setGroups(newGroups);
-        dataManager.savePlayerData(uuidString, data, new IOCallback<>() {
+        dataManager.savePlayerDataAsync(uuidString, data, new IOCallback<>() {
             @Override
             public void success(Void data) {
                 sender.sendMessage("Sucessfully saved");
@@ -320,7 +320,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
 
         groups.add(group);
         groups.remove("default");
-        dataManager.savePlayerData(uuidString, data, new IOCallback<>() {
+        dataManager.savePlayerDataAsync(uuidString, data, new IOCallback<>() {
             @Override
             public void success(Void data) {
                 sender.sendMessage("Sucessfully saved");

--- a/src/main/java/net/simplyvanilla/simplyrank/command/SimplyRankCommandExecutor.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/command/SimplyRankCommandExecutor.java
@@ -71,7 +71,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
                         }
 
                         @Override
-                        public void error(IOException error) {
+                        public void error(Exception error) {
                             sender.sendMessage("An error occurred!");
                         }
                     });
@@ -120,7 +120,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
                     }
 
                     @Override
-                    public void error(IOException error) {
+                    public void error(Exception error) {
                         if (error instanceof FileNotFoundException || error instanceof NoSuchFileException) {
                             coreSetCommandHandler(sender, group, uuidString, new PlayerData(new ArrayList<>()));
                             return;
@@ -172,7 +172,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
                     }
 
                     @Override
-                    public void error(IOException error) {
+                    public void error(Exception error) {
                         if (error instanceof FileNotFoundException || error instanceof NoSuchFileException) {
                             coreAddCommandHandler(sender, group, uuidString, new PlayerData(new ArrayList<>()));
                             return;
@@ -216,7 +216,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
                     }
 
                     @Override
-                    public void error(IOException error) {
+                    public void error(Exception error) {
                         sender.sendMessage("Could not load player data");
                     }
                 });
@@ -269,7 +269,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
                     }
 
                     @Override
-                    public void error(IOException error) {
+                    public void error(Exception error) {
                         sender.sendMessage("Player data not found.");
                     }
                 });
@@ -304,7 +304,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
             }
 
             @Override
-            public void error(IOException error) {
+            public void error(Exception error) {
                 sender.sendMessage("Saving failed");
             }
         });
@@ -327,7 +327,7 @@ public class SimplyRankCommandExecutor implements CommandExecutor {
             }
 
             @Override
-            public void error(IOException error) {
+            public void error(Exception error) {
                 sender.sendMessage("Saving failed");
             }
         });

--- a/src/main/java/net/simplyvanilla/simplyrank/data/DataManager.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/data/DataManager.java
@@ -5,28 +5,20 @@ import net.simplyvanilla.simplyrank.SimplyRankPlugin;
 import org.bukkit.Bukkit;
 
 import java.io.IOException;
-import java.io.Reader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
 public final class DataManager {
 
-    private final Map<UUID, PlayerData> playerDataCache = new HashMap<>();
-    private final Map<String, GroupData> groupDataCache = new HashMap<>();
+    private DataRepository repository;
 
-    private final Gson gson;
-    private final Path groupFolder;
-    private final Path playerDataFolder;
+    final Map<UUID, PlayerData> playerDataCache = new HashMap<>();
+    final Map<String, GroupData> groupDataCache = new HashMap<>();
 
     public DataManager(Gson gson, Path groupFolder, Path playerDataFolder) {
-        this.gson = gson;
-        this.groupFolder = groupFolder;
-        this.playerDataFolder = playerDataFolder;
+        repository = new DiskDataRepository(gson, groupFolder, playerDataFolder);
     }
 
     /**
@@ -36,8 +28,7 @@ public final class DataManager {
      * @param callback The callback to give the caller the ability to handle success and failure
      * @return
      */
-    public void loadPlayerData(UUID uuid, IOCallback<PlayerData, IOException> callback) {
-        String uuidString = uuid.toString();
+    public void loadPlayerDataAsync(UUID uuid, IOCallback<PlayerData, IOException> callback) {
         PlayerData cached = playerDataCache.get(uuid);
 
         if (cached != null) {
@@ -47,17 +38,16 @@ public final class DataManager {
 
         // Go into async
         Bukkit.getScheduler().runTaskAsynchronously(SimplyRankPlugin.getInstance(), () -> {
-            try (Reader fileReader = Files.newBufferedReader(getPlayerDataFile(uuidString), StandardCharsets.UTF_8)) {
-                PlayerData playerData = gson.fromJson(fileReader, PlayerData.class);
 
-                // Switch back to sync
-                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> {
-                    playerDataCache.put(uuid, playerData);
-                    callback.success(playerData);
-                });
-            } catch (IOException e) {
-                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.error(e));
-            }
+            var playerData = repository.loadPlayerData(uuid, callback);
+
+            // Switch back to sync
+            Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> {
+                playerDataCache.put(uuid, playerData);
+                callback.success(playerData);
+            });
+
+
         });
     }
 
@@ -67,7 +57,7 @@ public final class DataManager {
      * @param groupName The name of the group to load
      * @param callback  The callback which is called after the data has been loaded or failed to be loaded
      */
-    public void loadGroupData(String groupName, IOCallback<GroupData, IOException> callback) {
+    public void loadGroupDataAsync(String groupName, IOCallback<GroupData, IOException> callback) {
         GroupData cached = groupDataCache.get(groupName);
 
         if (cached != null) {
@@ -77,17 +67,14 @@ public final class DataManager {
 
         // Go into async
         Bukkit.getScheduler().runTaskAsynchronously(SimplyRankPlugin.getInstance(), () -> {
-            try (Reader fileReader = Files.newBufferedReader(getGroupFile(groupName), StandardCharsets.UTF_8)) {
-                GroupData groupData = gson.fromJson(fileReader, GroupData.class);
 
-                // Switch back to sync
-                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> {
-                    groupDataCache.put(groupName, groupData);
-                    callback.success(groupData);
-                });
-            } catch (IOException e) {
-                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.error(e));
-            }
+            var groupData = repository.loadGroupData(groupName, callback);
+            // Switch back to sync
+            Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> {
+                groupDataCache.put(groupName, groupData);
+                callback.success(groupData);
+            });
+
         });
     }
 
@@ -95,11 +82,7 @@ public final class DataManager {
         PlayerData playerData = playerDataCache.get(uuid);
 
         if (playerData == null) {
-            try (Reader fileReader = Files.newBufferedReader(getPlayerDataFile(uuid.toString()), StandardCharsets.UTF_8)) {
-                playerData = gson.fromJson(fileReader, PlayerData.class);
-            } catch (IOException e) {
-                playerData = PlayerData.getDefault();
-            }
+            playerData = repository.loadPlayerData(uuid, null);
             playerDataCache.put(uuid, playerData);
         }
 
@@ -110,61 +93,31 @@ public final class DataManager {
         GroupData groupData = groupDataCache.get(groupName);
 
         if (groupData == null) {
-            Reader fileReader = Files.newBufferedReader(getGroupFile(groupName), StandardCharsets.UTF_8);
-            groupData = gson.fromJson(fileReader, GroupData.class);
-            fileReader.close();
+            groupData = repository.loadGroupData(groupName, null);
             groupDataCache.put(groupName, groupData);
         }
 
         return groupData;
     }
 
-    public void savePlayerData(String uuidString, PlayerData playerData, IOCallback<Void, IOException> callback) {
+    public void savePlayerDataAsync(String uuidString, PlayerData playerData, IOCallback<Void, IOException> callback) {
         playerDataCache.put(UUID.fromString(uuidString), playerData);
         // Go into async
         Bukkit.getScheduler().runTaskAsynchronously(SimplyRankPlugin.getInstance(), () -> {
-            try {
-                Files.writeString(getPlayerDataFile(uuidString), gson.toJson(playerData), StandardCharsets.UTF_8, StandardOpenOption.CREATE);
-                // Switch back to sync
-                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.success(null));
-            } catch (IOException e) {
-                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.error(e));
-            }
+            repository.savePlayerData(uuidString, playerData, callback);
         });
     }
 
-    public void saveGroupData(String groupName, GroupData groupData, IOCallback<Void, IOException> callback) {
+    public void saveGroupDataAsync(String groupName, GroupData groupData, IOCallback<Void, IOException> callback) {
         groupDataCache.put(groupName, groupData);
         // Go into async
         Bukkit.getScheduler().runTaskAsynchronously(SimplyRankPlugin.getInstance(), () -> {
-            try {
-                Files.writeString(getGroupFile(groupName), gson.toJson(groupData), StandardCharsets.UTF_8, StandardOpenOption.CREATE);
-                // Switch back to sync
-                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.success(null));
-            } catch (IOException e) {
-                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.error(e));
-            }
+            repository.saveGroupData(groupName, groupData, callback);
         });
     }
 
-    public boolean groupExists(String group) {
-        return Files.exists(getGroupFile(group));
-    }
-
-    private Path getPlayerDataFile(String uuidString) {
-        return playerDataFolder.resolve(userDataFileName(uuidString));
-    }
-
-    private Path getGroupFile(String groupName) {
-        return groupFolder.resolve(groupDataFileName(groupName));
-    }
-
-    private static String userDataFileName(String uuidString) {
-        return uuidString + ".json";
-    }
-
-    private static String groupDataFileName(String groupName) {
-        return groupName + ".json";
+    public boolean groupExists(String groupName) {
+        return repository.groupExists(groupName);
     }
 
 }

--- a/src/main/java/net/simplyvanilla/simplyrank/data/DataManager.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/data/DataManager.java
@@ -14,11 +14,15 @@ public final class DataManager {
 
     private DataRepository repository;
 
-    final Map<UUID, PlayerData> playerDataCache = new HashMap<>();
-    final Map<String, GroupData> groupDataCache = new HashMap<>();
+    private final Map<UUID, PlayerData> playerDataCache = new HashMap<>();
+    private final Map<String, GroupData> groupDataCache = new HashMap<>();
 
     public DataManager(Gson gson, Path groupFolder, Path playerDataFolder) {
         repository = new DiskDataRepository(gson, groupFolder, playerDataFolder);
+    }
+
+    public DataManager(Gson gson, SQLHandler sqlHandler) {
+        repository = new SQLRepository(sqlHandler, gson);
     }
 
     /**
@@ -28,7 +32,7 @@ public final class DataManager {
      * @param callback The callback to give the caller the ability to handle success and failure
      * @return
      */
-    public void loadPlayerDataAsync(UUID uuid, IOCallback<PlayerData, IOException> callback) {
+    public void loadPlayerDataAsync(UUID uuid, IOCallback<PlayerData, Exception> callback) {
         PlayerData cached = playerDataCache.get(uuid);
 
         if (cached != null) {
@@ -57,7 +61,7 @@ public final class DataManager {
      * @param groupName The name of the group to load
      * @param callback  The callback which is called after the data has been loaded or failed to be loaded
      */
-    public void loadGroupDataAsync(String groupName, IOCallback<GroupData, IOException> callback) {
+    public void loadGroupDataAsync(String groupName, IOCallback<GroupData, Exception> callback) {
         GroupData cached = groupDataCache.get(groupName);
 
         if (cached != null) {
@@ -100,7 +104,7 @@ public final class DataManager {
         return groupData;
     }
 
-    public void savePlayerDataAsync(String uuidString, PlayerData playerData, IOCallback<Void, IOException> callback) {
+    public void savePlayerDataAsync(String uuidString, PlayerData playerData, IOCallback<Void, Exception> callback) {
         playerDataCache.put(UUID.fromString(uuidString), playerData);
         // Go into async
         Bukkit.getScheduler().runTaskAsynchronously(SimplyRankPlugin.getInstance(), () -> {
@@ -108,7 +112,7 @@ public final class DataManager {
         });
     }
 
-    public void saveGroupDataAsync(String groupName, GroupData groupData, IOCallback<Void, IOException> callback) {
+    public void saveGroupDataAsync(String groupName, GroupData groupData, IOCallback<Void, Exception> callback) {
         groupDataCache.put(groupName, groupData);
         // Go into async
         Bukkit.getScheduler().runTaskAsynchronously(SimplyRankPlugin.getInstance(), () -> {

--- a/src/main/java/net/simplyvanilla/simplyrank/data/DataRepository.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/data/DataRepository.java
@@ -9,11 +9,11 @@ public interface DataRepository {
         All methods are synchronous, unless specified
 
     */
-    public PlayerData loadPlayerData(UUID uuid, IOCallback<PlayerData, IOException> callback);
-    public GroupData loadGroupData(String groupName, IOCallback<GroupData, IOException> callback);
+    public PlayerData loadPlayerData(UUID uuid, IOCallback<PlayerData, Exception> callback);
+    public GroupData loadGroupData(String groupName, IOCallback<GroupData, Exception> callback);
 
-    public void savePlayerData(String uuidString, PlayerData playerData, IOCallback<Void, IOException> callback);
-    public void saveGroupData(String groupName, GroupData groupData, IOCallback<Void, IOException> callback);
+    public void savePlayerData(String uuidString, PlayerData playerData, IOCallback<Void, Exception> callback);
+    public void saveGroupData(String groupName, GroupData groupData, IOCallback<Void, Exception> callback);
 
     public boolean groupExists(String groupName);
 

--- a/src/main/java/net/simplyvanilla/simplyrank/data/DataRepository.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/data/DataRepository.java
@@ -1,0 +1,20 @@
+package net.simplyvanilla.simplyrank.data;
+
+import java.io.IOException;
+import java.util.UUID;
+
+public interface DataRepository {
+    /*
+
+        All methods are synchronous, unless specified
+
+    */
+    public PlayerData loadPlayerData(UUID uuid, IOCallback<PlayerData, IOException> callback);
+    public GroupData loadGroupData(String groupName, IOCallback<GroupData, IOException> callback);
+
+    public void savePlayerData(String uuidString, PlayerData playerData, IOCallback<Void, IOException> callback);
+    public void saveGroupData(String groupName, GroupData groupData, IOCallback<Void, IOException> callback);
+
+    public boolean groupExists(String groupName);
+
+}

--- a/src/main/java/net/simplyvanilla/simplyrank/data/DataRepository.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/data/DataRepository.java
@@ -9,12 +9,12 @@ public interface DataRepository {
         All methods are synchronous, unless specified
 
     */
-    public PlayerData loadPlayerData(UUID uuid, IOCallback<PlayerData, Exception> callback);
-    public GroupData loadGroupData(String groupName, IOCallback<GroupData, Exception> callback);
+    PlayerData loadPlayerData(UUID uuid, IOCallback<PlayerData, Exception> callback);
+    GroupData loadGroupData(String groupName, IOCallback<GroupData, Exception> callback);
 
-    public void savePlayerData(String uuidString, PlayerData playerData, IOCallback<Void, Exception> callback);
-    public void saveGroupData(String groupName, GroupData groupData, IOCallback<Void, Exception> callback);
+    void savePlayerData(String uuidString, PlayerData playerData, IOCallback<Void, Exception> callback);
+    void saveGroupData(String groupName, GroupData groupData, IOCallback<Void, Exception> callback);
 
-    public boolean groupExists(String groupName);
+    boolean groupExists(String groupName);
 
 }

--- a/src/main/java/net/simplyvanilla/simplyrank/data/DiskDataRepository.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/data/DiskDataRepository.java
@@ -1,0 +1,106 @@
+package net.simplyvanilla.simplyrank.data;
+
+import com.google.gson.Gson;
+import net.simplyvanilla.simplyrank.SimplyRankPlugin;
+import org.bukkit.Bukkit;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.UUID;
+
+public class DiskDataRepository implements DataRepository{
+
+    private final Gson gson;
+    private final Path groupFolder;
+    private final Path playerDataFolder;
+
+    public DiskDataRepository(Gson gson, Path groupFolder, Path playerDataFolder) {
+        this.gson = gson;
+        this.groupFolder = groupFolder;
+        this.playerDataFolder = playerDataFolder;
+    }
+
+    @Override
+    public PlayerData loadPlayerData(UUID uuid, IOCallback<PlayerData, IOException> callback) {
+
+        String uuidString = uuid.toString();
+
+        try (Reader fileReader = Files.newBufferedReader(getPlayerDataFile(uuidString), StandardCharsets.UTF_8)) {
+            PlayerData playerData = gson.fromJson(fileReader, PlayerData.class);
+            return playerData;
+        } catch (IOException e) {
+            if (callback != null)
+                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.error(e));
+            return PlayerData.getDefault();
+        }
+    }
+
+    @Override
+    public GroupData loadGroupData(String groupName, IOCallback<GroupData, IOException> callback) {
+
+        try (Reader fileReader = Files.newBufferedReader(getGroupFile(groupName), StandardCharsets.UTF_8)) {
+            GroupData groupData = gson.fromJson(fileReader, GroupData.class);
+            return groupData;
+        } catch (IOException e) {
+            if (callback != null)
+                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.error(e));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void savePlayerData(String uuidString, PlayerData playerData, IOCallback<Void, IOException> callback) {
+        try {
+            Files.writeString(getPlayerDataFile(uuidString), gson.toJson(playerData), StandardCharsets.UTF_8, StandardOpenOption.CREATE);
+
+            if (callback != null)
+                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.success(null));
+
+        } catch (IOException e) {
+            if (callback != null)
+                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.error(e));
+            else
+                e.printStackTrace(); //Not optimal but it should not go unnoticed.
+        }
+    }
+
+    @Override
+    public void saveGroupData(String groupName, GroupData groupData, IOCallback<Void, IOException> callback) {
+        try {
+            Files.writeString(getGroupFile(groupName), gson.toJson(groupData), StandardCharsets.UTF_8, StandardOpenOption.CREATE);
+            // Switch back to sync
+            if (callback != null)
+                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.success(null));
+        } catch (IOException e) {
+            if (callback != null)
+                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.error(e));
+            else
+                e.printStackTrace(); //Not optimal but it should not go unnoticed.
+        }
+    }
+
+    public boolean groupExists(String group) {
+        return Files.exists(getGroupFile(group));
+    }
+
+    private Path getPlayerDataFile(String uuidString) {
+        return playerDataFolder.resolve(userDataFileName(uuidString));
+    }
+
+    private Path getGroupFile(String groupName) {
+        return groupFolder.resolve(groupDataFileName(groupName));
+    }
+
+    private static String userDataFileName(String uuidString) {
+        return uuidString + ".json";
+    }
+
+    private static String groupDataFileName(String groupName) {
+        return groupName + ".json";
+    }
+}

--- a/src/main/java/net/simplyvanilla/simplyrank/data/DiskDataRepository.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/data/DiskDataRepository.java
@@ -25,7 +25,7 @@ public class DiskDataRepository implements DataRepository{
     }
 
     @Override
-    public PlayerData loadPlayerData(UUID uuid, IOCallback<PlayerData, IOException> callback) {
+    public PlayerData loadPlayerData(UUID uuid, IOCallback<PlayerData, Exception> callback) {
 
         String uuidString = uuid.toString();
 
@@ -40,7 +40,7 @@ public class DiskDataRepository implements DataRepository{
     }
 
     @Override
-    public GroupData loadGroupData(String groupName, IOCallback<GroupData, IOException> callback) {
+    public GroupData loadGroupData(String groupName, IOCallback<GroupData, Exception> callback) {
 
         try (Reader fileReader = Files.newBufferedReader(getGroupFile(groupName), StandardCharsets.UTF_8)) {
             GroupData groupData = gson.fromJson(fileReader, GroupData.class);
@@ -54,7 +54,7 @@ public class DiskDataRepository implements DataRepository{
     }
 
     @Override
-    public void savePlayerData(String uuidString, PlayerData playerData, IOCallback<Void, IOException> callback) {
+    public void savePlayerData(String uuidString, PlayerData playerData, IOCallback<Void, Exception> callback) {
         try {
             Files.writeString(getPlayerDataFile(uuidString), gson.toJson(playerData), StandardCharsets.UTF_8, StandardOpenOption.CREATE);
 
@@ -70,7 +70,7 @@ public class DiskDataRepository implements DataRepository{
     }
 
     @Override
-    public void saveGroupData(String groupName, GroupData groupData, IOCallback<Void, IOException> callback) {
+    public void saveGroupData(String groupName, GroupData groupData, IOCallback<Void, Exception> callback) {
         try {
             Files.writeString(getGroupFile(groupName), gson.toJson(groupData), StandardCharsets.UTF_8, StandardOpenOption.CREATE);
             // Switch back to sync

--- a/src/main/java/net/simplyvanilla/simplyrank/data/IOCallback.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/data/IOCallback.java
@@ -21,5 +21,6 @@ public interface IOCallback<T, E> {
      * @param error the error
      */
     void error(E error);
+    
 
 }

--- a/src/main/java/net/simplyvanilla/simplyrank/data/SQLHandler.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/data/SQLHandler.java
@@ -37,9 +37,8 @@ public class SQLHandler {
                 HOST: '%s:%s',
                 DATABASE: '%s',
                 USER: '%s',
-                PASSWORD, starting with '%s'
                 """,
-                HOST, PORT, DATABASE, USERNAME, PASSWORD.charAt(0)
+                HOST, PORT, DATABASE, USERNAME
                 ));
 
             connection = DriverManager.getConnection(
@@ -73,10 +72,12 @@ public class SQLHandler {
     }
 
     public ResultSet query(String qry) throws SQLException {
-        ResultSet rs = null;
+        ResultSet rs;
 
         Statement st = connection.createStatement();
         rs = st.executeQuery(qry);
+
+        st.closeOnCompletion();
 
         return rs;
     }

--- a/src/main/java/net/simplyvanilla/simplyrank/data/SQLHandler.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/data/SQLHandler.java
@@ -1,6 +1,9 @@
 package net.simplyvanilla.simplyrank.data;
 
+import org.bukkit.Bukkit;
+
 import java.sql.*;
+import java.util.logging.Level;
 
 public class SQLHandler {
 
@@ -28,6 +31,17 @@ public class SQLHandler {
 
     public void connect() {
         try {
+            Bukkit.getLogger().log(Level.INFO, String.format(
+                """
+                Trying to establish mysql connection with:
+                HOST: '%s:%s',
+                DATABASE: '%s',
+                USER: '%s',
+                PASSWORD, starting with '%s'
+                """,
+                HOST, PORT, DATABASE, USERNAME, PASSWORD.charAt(0)
+                ));
+
             connection = DriverManager.getConnection(
                 "jdbc:mysql://" + HOST + ":" + PORT + " /" + DATABASE + "?autoReconnect=true",
                 USERNAME,

--- a/src/main/java/net/simplyvanilla/simplyrank/data/SQLHandler.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/data/SQLHandler.java
@@ -1,0 +1,104 @@
+package net.simplyvanilla.simplyrank.data;
+
+import java.sql.*;
+
+public class SQLHandler {
+
+    public static final String TABLE_PLAYERS_NAME = "Players";
+    public static final String TABLE_GROUPS_NAME = "GroupData";
+
+    private final String HOST;
+    private final String DATABASE;
+    private final String USERNAME;
+    private final String PASSWORD;
+    private final String PORT;
+
+    private Connection connection;
+
+    public SQLHandler(String host, String database, String user, String password, String port) {
+        this.HOST = host;
+        this.DATABASE = database;
+        this.USERNAME = user;
+        this.PASSWORD = password;
+        this.PORT = port;
+
+        connect();
+        initTables();
+    }
+
+    public void connect() {
+        try {
+            connection = DriverManager.getConnection(
+                "jdbc:mysql://" + HOST + ":" + PORT + " /" + DATABASE + "?autoReconnect=true",
+                USERNAME,
+                PASSWORD);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void close() {
+        try {
+            if (connection != null)
+                connection.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void update(String qry) throws SQLException {
+        Statement st = connection.createStatement();
+        st.executeUpdate(qry);
+        st.close();
+    }
+
+    public void execute(String cmd) throws SQLException {
+        Statement st = connection.createStatement();
+        st.execute(cmd);
+        st.close();
+    }
+
+    public ResultSet query(String qry) throws SQLException {
+        ResultSet rs = null;
+
+        Statement st = connection.createStatement();
+        rs = st.executeQuery(qry);
+
+        return rs;
+    }
+
+    private void initTables() {
+
+       String cmdPlayers = String.format(
+           """
+              CREATE TABLE if not exists %s
+              (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY ,
+                uuid TEXT NOT NULL,
+                data TEXT NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP)
+           """,
+           TABLE_PLAYERS_NAME
+       );
+
+        String cmdGroups = String.format(
+            """
+              CREATE TABLE if not exists %s
+              (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY ,
+                name TEXT NOT NULL,
+                data TEXT NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP)
+           """,
+            TABLE_GROUPS_NAME
+        );
+
+       try {
+           execute(cmdPlayers);
+           execute(cmdGroups);
+       } catch (SQLException e) {
+           e.printStackTrace();
+       }
+    }
+
+}

--- a/src/main/java/net/simplyvanilla/simplyrank/data/SQLRepository.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/data/SQLRepository.java
@@ -1,0 +1,209 @@
+package net.simplyvanilla.simplyrank.data;
+
+import com.google.gson.Gson;
+import net.simplyvanilla.simplyrank.SimplyRankPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
+public class SQLRepository implements DataRepository {
+
+    private final SQLHandler sql;
+    private final Gson gson;
+
+    public SQLRepository(SQLHandler handler, Gson gson) {
+        this.sql = handler;
+        this.gson = gson;
+    }
+
+    @Override
+    public PlayerData loadPlayerData(UUID uuid, IOCallback<PlayerData, Exception> callback) {
+
+        var strUUID = uuid.toString();
+
+        if (!playerExists(uuid))
+            createPlayer(uuid);
+
+        try {
+            String qry = String.format("SELECT data FROM %s WHERE uuid='%s'", SQLHandler.TABLE_PLAYERS_NAME, strUUID);
+            var result = sql.query(qry);
+
+            if (!result.next()) {
+                return null;
+            }
+
+            String jsonString = result.getString("data");
+            if (jsonString == null) return null;
+
+            var playerData = gson.fromJson(jsonString, PlayerData.class);
+            return playerData;
+
+        } catch (SQLException e) {
+            if (callback != null)
+                callback.error(e);
+            else
+                e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    @Override
+    public GroupData loadGroupData(String groupName, IOCallback<GroupData, Exception> callback) {
+        try {
+            String qry = String.format("SELECT data FROM %s WHERE name='%s'", SQLHandler.TABLE_GROUPS_NAME, groupName);
+            var result = sql.query(qry);
+
+            if (!result.next()) {
+                return null;
+            }
+
+            String jsonString = result.getString("data");
+            if (jsonString == null) return null;
+
+            var groupData = gson.fromJson(jsonString, GroupData.class);
+            return groupData;
+
+        } catch (SQLException e) {
+            if (callback != null)
+                callback.error(e);
+            else
+                e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    @Override
+    public void savePlayerData(String uuidString, PlayerData playerData, IOCallback<Void, Exception> callback) {
+        if (!playerExists(uuidString))
+            createPlayer(uuidString);
+
+
+        try {
+            String qry = String.format("UPDATE %s SET data='%s' WHERE uuid='%s'",
+                SQLHandler.TABLE_PLAYERS_NAME, gson.toJson(playerData), uuidString);
+
+            sql.update(qry);
+
+            //Sync success
+            if (callback != null)
+                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.success(null));
+
+        } catch (SQLException e) {
+            if (callback != null)
+                callback.error(e);
+            else
+                e.printStackTrace();
+        }
+
+    }
+
+    @Override
+    public void saveGroupData(String groupName, GroupData groupData, IOCallback<Void, Exception> callback) {
+        String qry = String.format("UPDATE %s SET data='%s' WHERE name='%s'",
+            SQLHandler.TABLE_GROUPS_NAME, gson.toJson(groupData), groupName);
+
+
+        try {
+            if (groupExists(groupName)) {
+                sql.update(qry);
+            }
+            else {
+                createGroup(groupName, groupData);
+            }
+
+            //Sync success
+            if (callback != null)
+                Bukkit.getScheduler().runTask(SimplyRankPlugin.getInstance(), () -> callback.success(null));
+
+        } catch (SQLException e) {
+            if (callback != null)
+                callback.error(e);
+            else
+                e.printStackTrace();
+        }
+    }
+
+    @Override
+    public boolean groupExists(String name) {
+        try {
+            String qry = String.format("SELECT * FROM %s WHERE name='%s'", SQLHandler.TABLE_GROUPS_NAME ,name);
+            ResultSet result = sql.query(qry);
+
+            return result.next();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        return false;
+    }
+
+    public void createGroup(String name, GroupData data) throws SQLException {
+        String json = gson.toJson(data);
+
+        String qry = String.format(
+            """
+            INSERT INTO %s
+            (name, data)
+            VALUES
+            ('%s','%s')
+            """,
+            SQLHandler.TABLE_GROUPS_NAME,
+            name,
+            json
+        );
+
+        sql.update(qry);
+    }
+
+    public boolean playerExists(String uuidString) {
+        try {
+            String qry = String.format("SELECT * FROM %s WHERE uuid='%s'", SQLHandler.TABLE_PLAYERS_NAME, uuidString);
+            ResultSet result = sql.query(qry);
+
+            return result.next();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        return false;
+    }
+
+    public boolean playerExists(UUID uuid) {
+        return playerExists(uuid.toString());
+    }
+
+    public void createPlayer(String uuidString) {
+        var data = PlayerData.getDefault();
+        String json = gson.toJson(data);
+
+        String qry = String.format(
+            """
+            INSERT INTO %s
+            (uuid, data)
+            VALUES
+            ('%s','%s')
+            """,
+            SQLHandler.TABLE_PLAYERS_NAME,
+            uuidString,
+            json
+        );
+
+        try {
+            sql.update(qry);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void createPlayer(UUID uuid) {
+        createPlayer(uuid.toString());
+    }
+
+}

--- a/src/main/java/net/simplyvanilla/simplyrank/data/SQLRepository.java
+++ b/src/main/java/net/simplyvanilla/simplyrank/data/SQLRepository.java
@@ -29,9 +29,9 @@ public class SQLRepository implements DataRepository {
         if (!playerExists(uuid))
             createPlayer(uuid);
 
-        try {
-            String qry = String.format("SELECT data FROM %s WHERE uuid='%s'", SQLHandler.TABLE_PLAYERS_NAME, strUUID);
-            var result = sql.query(qry);
+        String qry = String.format("SELECT data FROM %s WHERE uuid='%s'", SQLHandler.TABLE_PLAYERS_NAME, strUUID);
+
+        try (var result = sql.query(qry);) {
 
             if (!result.next()) {
                 return null;
@@ -55,10 +55,10 @@ public class SQLRepository implements DataRepository {
 
     @Override
     public GroupData loadGroupData(String groupName, IOCallback<GroupData, Exception> callback) {
-        try {
-            String qry = String.format("SELECT data FROM %s WHERE name='%s'", SQLHandler.TABLE_GROUPS_NAME, groupName);
-            var result = sql.query(qry);
 
+        String qry = String.format("SELECT data FROM %s WHERE name='%s'", SQLHandler.TABLE_GROUPS_NAME, groupName);
+
+        try (var result = sql.query(qry)) {
             if (!result.next()) {
                 return null;
             }
@@ -68,13 +68,13 @@ public class SQLRepository implements DataRepository {
 
             var groupData = gson.fromJson(jsonString, GroupData.class);
             return groupData;
-
         } catch (SQLException e) {
             if (callback != null)
                 callback.error(e);
             else
                 e.printStackTrace();
         }
+
 
         return null;
     }
@@ -84,11 +84,10 @@ public class SQLRepository implements DataRepository {
         if (!playerExists(uuidString))
             createPlayer(uuidString);
 
+        String qry = String.format("UPDATE %s SET data='%s' WHERE uuid='%s'",
+            SQLHandler.TABLE_PLAYERS_NAME, gson.toJson(playerData), uuidString);
 
         try {
-            String qry = String.format("UPDATE %s SET data='%s' WHERE uuid='%s'",
-                SQLHandler.TABLE_PLAYERS_NAME, gson.toJson(playerData), uuidString);
-
             sql.update(qry);
 
             //Sync success
@@ -108,7 +107,6 @@ public class SQLRepository implements DataRepository {
     public void saveGroupData(String groupName, GroupData groupData, IOCallback<Void, Exception> callback) {
         String qry = String.format("UPDATE %s SET data='%s' WHERE name='%s'",
             SQLHandler.TABLE_GROUPS_NAME, gson.toJson(groupData), groupName);
-
 
         try {
             if (groupExists(groupName)) {
@@ -132,10 +130,9 @@ public class SQLRepository implements DataRepository {
 
     @Override
     public boolean groupExists(String name) {
-        try {
-            String qry = String.format("SELECT * FROM %s WHERE name='%s'", SQLHandler.TABLE_GROUPS_NAME ,name);
-            ResultSet result = sql.query(qry);
 
+        String qry = String.format("SELECT * FROM %s WHERE name='%s'", SQLHandler.TABLE_GROUPS_NAME ,name);
+        try (ResultSet result = sql.query(qry)) {
             return result.next();
         } catch (SQLException e) {
             e.printStackTrace();
@@ -163,10 +160,9 @@ public class SQLRepository implements DataRepository {
     }
 
     public boolean playerExists(String uuidString) {
-        try {
-            String qry = String.format("SELECT * FROM %s WHERE uuid='%s'", SQLHandler.TABLE_PLAYERS_NAME, uuidString);
-            ResultSet result = sql.query(qry);
 
+        String qry = String.format("SELECT * FROM %s WHERE uuid='%s'", SQLHandler.TABLE_PLAYERS_NAME, uuidString);
+        try (ResultSet result = sql.query(qry);) {
             return result.next();
         } catch (SQLException e) {
             e.printStackTrace();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,9 @@
+# Config for SimplyRank
+# Currently only for MySQL connections
+
+mysql:
+  host: 'localhost'
+  port: '3306'
+  username: 'root'
+  password: '1234'
+  database: 'minecraft-simplyrank'

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,6 +2,7 @@
 # Currently only for MySQL connections
 
 mysql:
+  active: true
   host: 'localhost'
   port: '3306'
   username: 'root'


### PR DESCRIPTION
Rem command is working now. I simply continued, where my predecessor left off. 
It supports using both the uuid and the playername.

Added MySQL-Support:
I firstly made a lot of effort refactoring the data part of the code. I separated the data acccessing and requesting logic. The DataManager is now only responsible for requesting the data, whereas so called repositories now serve the data requested. 
Currently, there is a `DiskDataRepository` and an `SQLDataRepository`. The latter is accessing the data from an SQL Database. 
In a config file, you can specify the SQL credentials and also activate or disable MySQL, in which case we would go back to on disk data. 
The `DiskDataRepository` is now mostly what used to be in the DataManager. So I haven't touched that logic much.

Also, I noticed that there are a lot of places, where we need some severe refactoring, mainly in the onCommand and onEnable methods. 
However, that is a project for another time.  